### PR TITLE
Add Airflow 3 balancer UI

### DIFF
--- a/airflow_balancer/tests/test_ui.py
+++ b/airflow_balancer/tests/test_ui.py
@@ -2,6 +2,8 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
+from airflow_pydantic.migration import _airflow_3
+from fastapi.testclient import TestClient
 
 from airflow_balancer import BalancerConfiguration
 from airflow_balancer.testing import pools
@@ -17,7 +19,10 @@ class TestAirflowPlugin:
             return pytest.skip("Airflow not installed")
 
         AirflowBalancerViewerPluginView()
-        AirflowBalancerViewerPlugin()
+        plugin = AirflowBalancerViewerPlugin()
+        if _airflow_3():
+            assert plugin.fastapi_apps[0]["url_prefix"] == "/airflow-balancer"
+            assert plugin.external_views[0]["href"] == "/airflow-balancer/"
 
     # def test_plugin_view(self):
     #     with patch("airflow_balancer.ui.viewer.expose") as mock_expose, \
@@ -66,13 +71,16 @@ class TestPluginFunctions:
 
 class TestStandaloneUI:
     def test_standalone_ui(self):
-        # Test the build_app function
         app = build_app()
-        assert app is not None
+        client = TestClient(app)
+        response = client.get("/")
+        assert response.status_code == 200
+        assert "airflow-balancer" in response.text
+        assert "yaml file not specified" in client.get("/hosts").text
+        assert "does-not-exist" in client.get("/hosts", params={"yaml": "/does-not-exist.yaml"}).text
 
     def test_launch(self):
-        # Test the main function
-        with patch("airflow_balancer.ui.standalone.run") as mock_run:
+        with patch("uvicorn.run") as mock_run:
             main()
             mock_run.assert_called_once()
 

--- a/airflow_balancer/ui/airflow.py
+++ b/airflow_balancer/ui/airflow.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import logging
 import os
 from pathlib import Path
 from typing import ClassVar
@@ -12,9 +11,10 @@ __all__ = (
     "AirflowBalancerViewerPluginView",
 )
 
-_log = logging.getLogger(__name__)
-
 try:
+    from airflow.api_fastapi.auth.managers.models.resource_details import AccessView
+    from airflow.api_fastapi.core_api.security import requires_access_view
+except ImportError:
     from airflow.configuration import conf
     from airflow.security import permissions
     from airflow.www.auth import has_access
@@ -34,7 +34,9 @@ try:
             """Create hosts view"""
             yaml = request.args.get("yaml")
             if not yaml:
-                return self.render_template("airflow_config/500.html", yaml="- yaml file not specified")
+                return self.render_template("airflow_balancer/500.html", yaml="- yaml file not specified")
+            if not Path(yaml).is_file():
+                return self.render_template("airflow_balancer/500.html", yaml=yaml)
             try:
                 config = get_hosts_from_yaml(yaml)
             except FileNotFoundError:
@@ -82,13 +84,37 @@ try:
         appbuilder_views: ClassVar[list] = [view_subitem]
         appbuilder_menu_items: ClassVar[list] = [docs_link_subitem]
 
-except ImportError:
-    _log.info("airflow-balancer UI plugin disabled: airflow.www / Flask-AppBuilder not available (Airflow 3+)")
+else:
+    from fastapi import Depends
+
+    from .standalone import build_app
 
     class AirflowBalancerViewerPluginView:  # type: ignore[no-redef]
         pass
 
     class AirflowBalancerViewerPlugin(AirflowPlugin):  # type: ignore[no-redef]
-        """No-op plugin when Flask-AppBuilder UI is not available."""
+        """Airflow 3 FastAPI viewer plugin."""
 
         name = "Airflow Balancer"
+        fastapi_apps: ClassVar[list] = [
+            {
+                "app": build_app(dependencies=[Depends(requires_access_view(AccessView.WEBSITE))]),
+                "url_prefix": "/airflow-balancer",
+                "name": "Airflow Balancer Viewer",
+            }
+        ]
+        external_views: ClassVar[list] = [
+            {
+                "name": "Airflow Balancer Viewer",
+                "href": "/airflow-balancer/",
+                "destination": "nav",
+                "category": "admin",
+                "url_route": "airflow-balancer",
+            },
+            {
+                "name": "Airflow Balancer Docs",
+                "href": "https://airflow-laminar.github.io/airflow-balancer/",
+                "destination": "nav",
+                "category": "docs",
+            },
+        ]

--- a/airflow_balancer/ui/standalone/__init__.py
+++ b/airflow_balancer/ui/standalone/__init__.py
@@ -1,13 +1,10 @@
 import os
 from pathlib import Path
+from typing import Any
 
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
-
-# from airflow import __file__ as airflow_root
-from flask_appbuilder import __file__ as flask_appbuilder_root
-from uvicorn import run
 
 from ..functions import get_hosts_from_yaml, get_yaml_files
 
@@ -25,13 +22,13 @@ class AD(dict):
 
 def _url_for(name: str, filename: str, **kwargs) -> str:
     if name == "Airflow Balancer.static":
-        return f"/static/{filename}"
+        return f"static/{filename}"
     return ""
 
 
-def build_app() -> FastAPI:
+def build_app(*, dependencies: list[Any] | None = None) -> FastAPI:
     # Create a FastAPI instance
-    app = FastAPI()
+    app = FastAPI(dependencies=dependencies)
 
     # Serve static files
     app.mount(
@@ -51,7 +48,6 @@ def build_app() -> FastAPI:
         directory=[
             Path(__file__).parent.parent / "templates" / "airflow_balancer",
             Path(__file__).parent / "templates",
-            Path(flask_appbuilder_root).parent / "templates",
         ],
     )
 
@@ -77,27 +73,39 @@ def build_app() -> FastAPI:
         "current_user": AD(is_anonymous=True),
         "session": {"locale": "en"},
         "_": lambda *args, **kwargs: "",
+        "baselib": AD(get_nonce=lambda: ""),
     }
 
     @app.get("/")
-    async def home():
+    async def home(request: Request):
         dags_folder = os.environ.get("AIRFLOW__CORE__DAGS_FOLDER", os.environ.get("AIRFLOW_HOME", Path(__file__).parent.parent.parent / "tests"))
         if not dags_folder:
-            return templates.TemplateResponse("airflow_balancer/404.html", fab_common_mock)
+            return templates.TemplateResponse(request, "404.html", fab_common_mock)
         yamls, yamls_airflow_config = get_yaml_files(dags_folder)
-        return templates.TemplateResponse("home.html", {"yamls": yamls, "yamls_airflow_config": yamls_airflow_config, **fab_common_mock})
+        return templates.TemplateResponse(
+            request,
+            "home.html",
+            {"yamls": yamls, "yamls_airflow_config": yamls_airflow_config, **fab_common_mock},
+        )
 
     @app.get("/hosts")
-    async def hosts(yaml: str = ""):
+    async def hosts(request: Request, yaml: str = ""):
         if not yaml:
-            return templates.TemplateResponse("airflow_balancer/500.html", {"yaml": "- yaml file not specified", **fab_common_mock})
-        config = get_hosts_from_yaml(yaml)
-        return templates.TemplateResponse("hosts.html", {"config": config, **fab_common_mock})
+            return templates.TemplateResponse(request, "500.html", {"yaml": "- yaml file not specified", **fab_common_mock})
+        if not Path(yaml).is_file():
+            return templates.TemplateResponse(request, "500.html", {"yaml": yaml, **fab_common_mock})
+        try:
+            config = get_hosts_from_yaml(yaml)
+        except FileNotFoundError:
+            return templates.TemplateResponse(request, "500.html", {"yaml": yaml, **fab_common_mock})
+        return templates.TemplateResponse(request, "hosts.html", {"config": config, **fab_common_mock})
 
     return app
 
 
 def main():
+    from uvicorn import run
+
     app = build_app()
 
     # Run the application using Uvicorn

--- a/airflow_balancer/ui/standalone/templates/airflow_mock.html
+++ b/airflow_balancer/ui/standalone/templates/airflow_mock.html
@@ -1,20 +1,20 @@
-{% extends 'appbuilder/baselayout.html' %}
-
-{% block head_css %}
-  {{ super() }}
-  <link rel="stylesheet" type="text/css" href="static_airflow/airflowDefaultTheme.css">
-  <link rel="stylesheet" type="text/css" href="static_airflow/materialIcons.css">
-  <link rel="stylesheet" type="text/css" href="static_airflow/main.css">
-  <!-- <link rel="stylesheet" type="text/css" href="loadingDots.css"> -->
-  <!-- <link rel="stylesheet" type="text/css" href="bootstrap-datetimepicker.min.css"> -->
-{% endblock %}
-
-{% block tail_js %}
-  {{ super() }}
-  <!-- <script src="moment.js"></script> -->
-  <!-- <script src="main.js"></script> -->
-  <!-- <script src="bootstrap-datetimepicker.min.js"></script> -->
-  <!-- <script src="bootstrap3-typeahead.min.js"></script> -->
-  <!-- <script src="toggleTheme.js"></script> -->
-  <!-- <script src="moment.js"></script> -->
-{% endblock %}
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>airflow-balancer</title>
+    {% block head_css %}
+      <link rel="stylesheet" type="text/css" href="static_airflow/airflowDefaultTheme.css">
+      <link rel="stylesheet" type="text/css" href="static_airflow/materialIcons.css">
+      <link rel="stylesheet" type="text/css" href="static_airflow/main.css">
+    {% endblock %}
+    {% block head_js %}{% endblock %}
+  </head>
+  <body>
+    <main class="container">
+      {% block content %}{% endblock %}
+    </main>
+    {% block tail_js %}{% endblock %}
+  </body>
+</html>

--- a/airflow_balancer/ui/standalone/templates/appbuilder/base.html
+++ b/airflow_balancer/ui/standalone/templates/appbuilder/base.html
@@ -1,0 +1,1 @@
+{% extends "airflow_mock.html" %}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ airflow = [
     "apache-airflow-providers-standard",
 ]
 airflow3 = [
-    "apache-airflow>=3,<3.2",
+    "apache-airflow>=3,<3.4",
     "apache-airflow-providers-ssh",
     "apache-airflow-providers-standard",
 ]


### PR DESCRIPTION
## Description

Restore the airflow-balancer plugin UI on Airflow 3 with an authenticated FastAPI application and native external-view navigation. Retain the existing Flask-AppBuilder integration on Airflow 2.

Make the embedded viewer self-contained so runtime rendering no longer depends on Flask-AppBuilder, fix missing-YAML error rendering, and extend the supported Airflow 3 bound through `<3.4`.

Validated with Ruff, the full pytest suite (18 passed, 1 skipped), wheel inspection, Airflow 2.11 route checks, and authenticated Airflow 3.3 HTML/static route checks.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / code cleanup
- [ ] CI / build configuration
- [ ] Other (describe below)

## Checklist

- [x] Linting passes (`ruff check` and `ruff format --check`)
- [x] Tests pass (`pytest`)
- [x] New tests added for new functionality
- [x] Documentation updated (not applicable)
- [x] Changelog / version bump (not applicable)